### PR TITLE
add Era Phase2C11I13T25M9 and use it where appropriate

### DIFF
--- a/Configuration/Eras/python/Era_Phase2C11I13T25M9_cff.py
+++ b/Configuration/Eras/python/Era_Phase2C11I13T25M9_cff.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Eras.Era_Phase2C11I13_cff import Phase2C11I13
+from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels
+from Configuration.Eras.Modifier_phase2_GE0_cff import phase2_GE0
+
+Phase2C11I13T25M9 = cms.ModifierChain(Phase2C11I13, phase2_3DPixels, phase2_GE0)

--- a/Configuration/Geometry/python/dict2026Geometry.py
+++ b/Configuration/Geometry/python/dict2026Geometry.py
@@ -325,7 +325,7 @@ trackerDict = {
             'from Geometry.TrackerGeometryBuilder.idealForDigiTrackerGeometry_cff import *',
             'trackerGeometry.applyAlignment = cms.bool(False)',
         ],
-        "era" : "phase2_tracker, trackingPhase2PU140",
+        "era" : "phase2_tracker, phase2_3DPixels, trackingPhase2PU140",
     },
     "T26" : {
         1 : [

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -1288,14 +1288,14 @@ upgradeProperties[2026] = {
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D80' : {
-        'Geom' : 'Extended2026D80', # N.B.: Geometry with 3D pixels in the Inner Tracker.
+        'Geom' : 'Extended2026D80', # N.B.: Geometry with 3D pixels in the Inner Tracker L1.
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T25',
-        'Era' : 'Phase2C11I13M9', 
+        'Era' : 'Phase2C11I13T25M9', # customized for 3D pixels and Muon M9
         'ScenToRun' : ['GenSimHLBeamSpot','DigiTrigger','RecoGlobal', 'HARVESTGlobal'],
     },
     '2026D81' : {
-        'Geom' : 'Extended2026D81', # N.B.: Geometry with 3D pixels and square 50x50 um2 pixels in the Inner Tracker.
+        'Geom' : 'Extended2026D81', # N.B.: Geometry with 3D pixels (TBPX,L1) and square 50x50 um2 pixels (TFPX+TEPX) in the Inner Tracker.
         'HLTmenu': '@fake2',
         'GT' : 'auto:phase2_realistic_T26',
         'Era' : 'Phase2C11I13T26M9', # customized for square pixels and Muon M9

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -50,6 +50,7 @@ class Eras (object):
                  'Phase2C11I13M9',
                  'Phase2C11I13T22M9',
                  'Phase2C11I13T23M9',
+                 'Phase2C11I13T25M9',
                  'Phase2C11I13T26M9'
         ]
 

--- a/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
+++ b/RecoLocalTracker/SiPixelRecHits/python/PixelCPEGeneric_cfi.py
@@ -23,16 +23,17 @@ phase2_tracker.toModify(PixelCPEGenericESProducer,
 # customize the Pixel CPE generic producer for phase2 3D pixels
 # Will remove any usage of template / genError payloads from the reconstruction
 from Configuration.Eras.Modifier_phase2_3DPixels_cff import phase2_3DPixels
-(phase2_tracker & phase2_3DPixels).toModify(PixelCPEGenericESProducer,
-                                            UseErrorsFromTemplates = False,    # no GenErrors
-                                            LoadTemplatesFromDB = False,       # do not load templates
-                                            )
+from Configuration.ProcessModifiers.PixelCPEGeneric_cff import PixelCPEGeneric
+(phase2_tracker & (phase2_3DPixels & PixelCPEGeneric)).toModify(PixelCPEGenericESProducer,
+                                                                UseErrorsFromTemplates = False,    # no GenErrors
+                                                                LoadTemplatesFromDB = False,       # do not load templates
+                                                                )
 
 # customize the Pixel CPE generic producer for phase2 square pixels
 # Do use Template errors for square pixels even in the first tracking step
 # This is needed because hardcoded errors in https://github.com/cms-sw/cmssw/blob/master/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc#L113
 # have been optimized for rectangular 25x100 pixels, and in the current generic reco setup we use hardcoded errors for the first tracking pass
 from Configuration.Eras.Modifier_phase2_squarePixels_cff import phase2_squarePixels
-(phase2_tracker & phase2_squarePixels).toModify(PixelCPEGenericESProducer,
-                                                NoTemplateErrorsWhenNoTrkAngles = False # use genErrors in the seeding step (when no track angles are available)
-                                                )
+(phase2_tracker & (phase2_squarePixels | phase2_3DPixels)).toModify(PixelCPEGenericESProducer,
+                                                                    NoTemplateErrorsWhenNoTrkAngles = False # use genErrors in the seeding step (when no track angles are available)
+                                                                    )


### PR DESCRIPTION
Title says it all, 
validated with:
```python
 runTheMatrix.py --what upgrade -nel 36207.0,36607.0,35807.0
```
gave:

```
35807.0_SingleMuPt10+2026D79+SingleMuPt10_Eta2p85_GenSimHLBeamSpot+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 18 22:30:54 2021-date Thu Mar 18 22:19:15 2021; exit: 0 0 0 0
36207.0_SingleMuPt10+2026D80+SingleMuPt10_Eta2p85_GenSimHLBeamSpot+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 18 22:30:36 2021-date Thu Mar 18 22:19:16 2021; exit: 0 0 0 0
36607.0_SingleMuPt10+2026D81+SingleMuPt10_Eta2p85_GenSimHLBeamSpot+DigiTrigger+RecoGlobal+HARVESTGlobal Step0-PASSED Step1-PASSED Step2-PASSED Step3-PASSED  - time date Thu Mar 18 22:30:36 2021-date Thu Mar 18 22:19:16 2021; exit: 0 0 0 0
3 3 3 3 tests passed, 0 0 0 0 failed
```
